### PR TITLE
Fix permalinks when id attribute is not present

### DIFF
--- a/source/assets/javascripts/main.js.coffee
+++ b/source/assets/javascripts/main.js.coffee
@@ -46,9 +46,18 @@ UI.Anchor =
 ###
 UI.Permalink =
   bindListeners: ($domElement) ->
-    $domElement.one 'mouseover.ui.Permalink', (e) ->
-      if $(@).find('a.permalink').length is 0 and $(@).attr('id')
-        $(@).append('<a href="#' + $(@).attr('id') + '" class="permalink"></a>')
+    $domElement
+      .one 'mouseover.ui.Permalink', (e) =>
+        $target  = $(e.currentTarget)
+        fragment = $target.attr('id')
+
+        if $target.find('a.permalink').length is 0 and fragment
+          $target.append($(@_link_template(fragment)))
+      .on 'click.ui.Permalink', '.permalink', (e) ->
+         e.preventDefault()
+         UI.Anchor.scrollToTarget @hash
+
+  _link_template: (id) -> '<a href="#' + id + '" class="permalink"></a>'
 
 ###
   UI.BackToTop

--- a/source/localizable/docs.html.erb
+++ b/source/localizable/docs.html.erb
@@ -13,7 +13,7 @@ title: docs
       <div class="panel-doc">
         <div class="doc-icon"><i class="<%= doc.icon %>"></i></div>
         <div class="doc-body">
-          <h3 class="heading">
+          <h3 class="heading" id="<%= key.dasherize %>">
             <%= t("titles.#{key}", flavor: settings.site_name.titleize) %>
             <% if doc.deprecated %>
               <span class="label label-warning"><%= t('common.deprecated') %></span>


### PR DESCRIPTION
Fixes the permalinks to `#undefined` caused when the `id` attribute is missing at header elements.
