### PR TITLE
Toggle http-headers only for the concerned response

### DIFF
--- a/source/assets/javascripts/main.js.coffee
+++ b/source/assets/javascripts/main.js.coffee
@@ -161,7 +161,7 @@ class UI.ResponseHeaders
 
   toggleHeader: (e) ->
     $el = $(e.currentTarget)
-    $headers = $($el.data('target'))
+    $headers = $el.siblings($el.data('target'))
 
     if $headers.hasClass(HIDDEN_CLASS)
       $el.text($el.data('hideText'))


### PR DESCRIPTION
Fix issue where toggling http-headers of a response triggers toggling http-headers for all the responses.
