### PR TITLE
Scrolling issue

### DIFF
--- a/source/assets/javascripts/main.js.coffee
+++ b/source/assets/javascripts/main.js.coffee
@@ -191,5 +191,6 @@ UI.Table =
     UI.CodeExample.bindListeners $('.example').find('.toggler')
     new UI.ResponseHeaders('.http-headers-toggler')
     UI.Table.addResponsiveWrapper()
+    UI.Anchor.scrollToTarget(location.hash, 0) if location.hash isnt '#'
 
 )(window, document, jQuery)


### PR DESCRIPTION
Using history.pushstate instead of location.hash fixes the issue that hides the title of a section
