### PR TITLE
Remove response_type param from user token request

### DIFF
--- a/source/localizable/authorization/flows.html.md.erb
+++ b/source/localizable/authorization/flows.html.md.erb
@@ -92,7 +92,6 @@ Name            | Type   | Value               | Required | Description
 `client_id`     | String |                     | Yes      | The application client ID supplied by <%= settings.site_name.capitalize %>
 `client_secret` | String |                     | Yes      | The application client secret supplied by <%= settings.site_name.capitalize %>
 `redirect_uri`  | String |                     | Yes      | The redirect uri of the application
-`response_type` | String | `code`              | Yes      | The type of the response. Value must be `code`.
 `grant_type`    | String | `authorization_code`| Yes      | The grant type of the request. Value must be `authorization_code`.
 `code`          | String |                     | Yes      | The authorization code obtained
 


### PR DESCRIPTION
The `response_type=code` param is not necessary when you already have a
code from the authorization step.