### PR TITLE
Analytics/ecommerce additem name

### DIFF
--- a/resources/code_examples/analytics/complete_example.yml
+++ b/resources/code_examples/analytics/complete_example.yml
@@ -4,9 +4,9 @@
   <script>
     sa('ecommerce', 'addOrder', JSON.stringify({
       order_id: '123456',  // Order ID. Required.
-      revenue:  '87.45',   // Grand Total. Includes Tax and Shipping.
+      revenue:  '4417.58', // Grand Total. Includes Tax and Shipping.
       shipping: '5.45',    // Total Shipping Cost.
-      tax:      '10.50'    // Total Tax.
+      tax:      '1014.79'  // Total Tax.
     }));
   </script>
   
@@ -15,21 +15,24 @@
     sa('ecommerce', 'addItem', JSON.stringify({
       order_id:   '123456',  // Order ID. Required.
       product_id: '111222',  // Product ID. Required.
-      price:      '5.50',    // Price per Unit. Required.
+      name:       'Apple IPhone 6 Plus (16GB) Space Gray EU',  // Product Name. Required.
+      price:      '654.90',  // Price per Unit. Required.
       quantity:   '4'        // Quantity of Items. Required.
     }));
   
     sa('ecommerce', 'addItem', JSON.stringify({
       order_id:   '123456',
       product_id: '303404',
-      price:      '60.00',
+      name:       'Motorola Nexus 6 (64GB) EU Light Gray',
+      price:      '590.99',
       quantity:   '1'
     }));
   
     sa('ecommerce', 'addItem', JSON.stringify({
       order_id:   '123456',
       product_id: '121234',
-      price:      '16.77',
+      name:       'LG G4 (64GB) EU Leather',
+      price:      '600.77',
       quantity:   '2'
     }));
   </script>

--- a/resources/code_examples/analytics/examples/php/order_declaration.yml
+++ b/resources/code_examples/analytics/examples/php/order_declaration.yml
@@ -5,21 +5,23 @@
   // Example of an Order to report with Analytics
   $order = array(
     'id'        => 123456,
-    'revenue'   => '300.50',
+    'revenue'   => '1840.38',
     'shipping'  => '3.50',
-    'tax'       => '10.00'
+    'tax'       => '422.49'
   );
 
   // Example of Order Items to report with Analytics
   $items = array();
   $items[0] = array(
     'id'        => 43667,
-    'price'     => '97.00',
+    'name'      => 'Apple IPhone 6 Plus (16GB) Space Gray EU',
+    'price'     => '654.90',
     'quantity'  => 1
   );
   $items[1] = array(
     'id'        => 25668,
-    'price'     => '100.00',
+    'name'      => 'Motorola Nexus 6 (64GB) EU Light Gray',
+    'price'     => '590.99',
     'quantity'  => 2
   );
 

--- a/resources/code_examples/analytics/examples/php/order_preprocessing.yml
+++ b/resources/code_examples/analytics/examples/php/order_preprocessing.yml
@@ -24,6 +24,7 @@
     $item_data = json_encode(array(
       'order_id'    => $order['id'],
       'product_id'  => $item['id'],
+      'name'        => $item['name'],
       'price'       => $item['price'],
       'quantity'    => $item['quantity']
     ));

--- a/resources/code_examples/analytics/item_beacon.yml
+++ b/resources/code_examples/analytics/item_beacon.yml
@@ -4,7 +4,8 @@
     sa('ecommerce', 'addItem', JSON.stringify({
       order_id:   '123456',  // Order ID. Required.
       product_id: '111222',  // Product ID. Required.
-      price:      '5.50',    // Price per Unit. Required.
-      quantity:   '4'        // Quantity of Items. Required.
+      name:       'Apple IPhone 6 Plus (16GB) Space Gray EU',  // Product Name. Required.
+      price:      '654.90',  // Price per Unit. Required.
+      quantity:   '2'        // Quantity of Items. Required.
     }));
   </script>

--- a/resources/code_examples/analytics/order_beacon.yml
+++ b/resources/code_examples/analytics/order_beacon.yml
@@ -2,9 +2,9 @@
 :code: |
   <script>
     sa('ecommerce', 'addOrder', JSON.stringify({
-      order_id: '123456',  // Order ID. Required.
-      revenue:  '120.99',  // Grand Total. Includes Tax and Shipping.
-      shipping: '5.45',    // Total Shipping Cost.
-      tax:      '10.50'    // Total Tax.
+      order_id: '123456',   // Order ID. Required.
+      revenue:  '1315.25',  // Grand Total. Includes Tax and Shipping.
+      shipping: '5.45',     // Total Shipping Cost.
+      tax:      '301.25'    // Total Tax.
     }));
   </script>

--- a/source/localizable/analytics/ecommerce.html.md.erb
+++ b/source/localizable/analytics/ecommerce.html.md.erb
@@ -45,7 +45,7 @@ The `addItem` command adds a new Ecommerce item object.
 Name          | Type   | Required | Description
 ------------- | ------ | -------- | -----------
 `order_id`    | String | Yes      | The Order ID that was produced by your e-shop. This ID links items to their orders.
-`product_id`  | String | Yes      | The Product ID from your e-shop.
+`product_id`  | String | Yes      | The [Unique ID](/feedspec/#unique-id) from your e-shop.
 `price`       | String | Yes      | The individual, unit, final price for each item.
 `quantity`    | String | Yes      | The number of units purchased in the order.
 

--- a/source/localizable/analytics/ecommerce.html.md.erb
+++ b/source/localizable/analytics/ecommerce.html.md.erb
@@ -46,13 +46,16 @@ Name          | Type   | Required | Description
 ------------- | ------ | -------- | -----------
 `order_id`    | String | Yes      | The Order ID that was produced by your e-shop. This ID links items to their orders.
 `product_id`  | String | Yes      | The [Unique ID](/feedspec/#unique-id) from your e-shop.
+`name`        | String | Yes      | The [name](/feedspec/#name) of the product from your e-shop.
 `price`       | String | Yes      | The individual, unit, final price for each item.
 `quantity`    | String | Yes      | The number of units purchased in the order.
 
 > ##### Note
-> 1. As the `Product ID` you **have to** provide the same [Unique ID](/feedspec/#unique-id) that is
+> 1. As the `Product ID` you **must** provide the same [Unique ID](/feedspec/#unique-id) that is
 > submitted as part of the XML feedspec.
-> 2. Make sure your `Order ID` in your `addItem` command matches the one submitted by `addOrder`.
+> 2. The `name` of the product **must** match the [Name](/feedspec/#name) that is
+> submitted as part of the XML feedspec.
+> 3. Make sure your `Order ID` in your `addItem` command matches the one submitted by `addOrder`.
 
 ##### Example
 


### PR DESCRIPTION
Require the product name of the line item at Analytics Ecommerce `addItem`.

> Product names **must** match the [Data Feed Specification#Name](http://localhost:4567/feedspec/#name) attribute.