### PR TITLE
Add note in addOrder command about spot cash

### DIFF
--- a/source/localizable/analytics/ecommerce.html.md.erb
+++ b/source/localizable/analytics/ecommerce.html.md.erb
@@ -33,6 +33,9 @@ Name       | Type   | Required | Description
 `shipping` | String | Yes      | The total shipping cost of the order.
 `tax`      | String | Yes      | The total tax of the order.
 
+> ##### Note
+> Make sure **not** to include any spot cash costs in either `revenue` or `shipping`.
+
 ##### Example
 
 <%= render_code_from_file 'analytics/order_beacon' %>


### PR DESCRIPTION
We have to clarify that spot cash costs should not be reported, as there are shops currently adding the spot cash amount to either the shipping or the revenue.