### PR TITLE
Correct order id in analytics addOrder command example

### DIFF
--- a/resources/code_examples/analytics/examples/php/order_declaration.yml
+++ b/resources/code_examples/analytics/examples/php/order_declaration.yml
@@ -4,7 +4,7 @@
 
   // Example of an Order to report with Analytics
   $order = array(
-    'id'        => 123456,
+    'order_id'  => 123456,
     'revenue'   => '1840.38',
     'shipping'  => '3.50',
     'tax'       => '422.49'
@@ -13,13 +13,13 @@
   // Example of Order Items to report with Analytics
   $items = array();
   $items[0] = array(
-    'id'        => 43667,
+    'order_id'  => 43667,
     'name'      => 'Apple IPhone 6 Plus (16GB) Space Gray EU',
     'price'     => '654.90',
     'quantity'  => 1
   );
   $items[1] = array(
-    'id'        => 25668,
+    'order_id'  => 25668,
     'name'      => 'Motorola Nexus 6 (64GB) EU Light Gray',
     'price'     => '590.99',
     'quantity'  => 2

--- a/resources/code_examples/analytics/examples/php/order_preprocessing.yml
+++ b/resources/code_examples/analytics/examples/php/order_preprocessing.yml
@@ -10,7 +10,7 @@
   function addOrderAction(&$order) {
     $order_data = json_encode($order);
 
-    return "sa('ecommerce', 'addOrder', {$order_data});";
+    return "sa('ecommerce', 'addOrder', '{$order_data}');";
   }
 
   /**
@@ -22,7 +22,7 @@
    */
   function addItemAction(&$order, &$item) {
     $item_data = json_encode(array(
-      'order_id'    => $order['id'],
+      'order_id'    => $order['order_id'],
       'product_id'  => $item['id'],
       'name'        => $item['name'],
       'price'       => $item['price'],


### PR DESCRIPTION
Currently we display an invalid example in [#prepare-ecommerce-data](http://developer.skroutz.gr/analytics/examples/#prepare-ecommerce-data) where we're creating orders with `id` instead of `order_id` required by [#addOrder](http://developer.skroutz.gr/analytics/ecommerce/#addorder).
