### PR TITLE
Add info for integrators verification link

### DIFF
--- a/data/alve.yml
+++ b/data/alve.yml
@@ -10,6 +10,7 @@ engineering_blog_domain: ''
 feed_validator_domain: ''
 
 api_email: 'api@alve.com'
+analytics_email: 'analytics@alve.com'
 
 github_profile: 'https://github.com/skroutz'
 apiv3_early_access_form: 'http://docs.google.com/forms/d/1mUk6pvAXR7yiMqtau8FWnBFamKCY320fL70El_RgN68/viewform'

--- a/data/scrooge.yml
+++ b/data/scrooge.yml
@@ -10,6 +10,7 @@ engineering_blog_domain: ''
 feed_validator_domain: ''
 
 api_email: 'api@scrooge.co.uk'
+analytics_email: 'analytics@scrooge.co.uk'
 
 github_profile: 'https://github.com/skroutz'
 apiv3_early_access_form: 'http://docs.google.com/forms/d/1mUk6pvAXR7yiMqtau8FWnBFamKCY320fL70El_RgN68/viewform'

--- a/data/skroutz.yml
+++ b/data/skroutz.yml
@@ -10,6 +10,7 @@ engineering_blog_domain: 'engineering.skroutz.gr'
 feed_validator_domain: 'validator.skroutz.gr'
 
 api_email: 'api@skroutz.gr'
+analytics_email: 'analytics@skroutz.gr'
 
 github_profile: 'https://github.com/skroutz'
 apiv3_early_access_form: 'http://docs.google.com/forms/d/1mUk6pvAXR7yiMqtau8FWnBFamKCY320fL70El_RgN68/viewform'

--- a/source/localizable/analytics/faq.html.md.erb
+++ b/source/localizable/analytics/faq.html.md.erb
@@ -23,6 +23,7 @@ What about browser support?
 : The script is tested to work on all modern browsers: Internet Explorer > 6, Chrome, Firefox, Opera, Safari.
 
 How can I confirm that the script is sending data properly?
-: Currently there is no way to check whether the script is reporting properly. Please, after you add the script,
-contact us and we will check if the script is installed correcly. In the meantime we are working hard to bring
-you information about the integration status and reports.
+: In order to check if the script is reporting properly we offer a developer page with info about the reported data,
+which is accessible only during the testing phase of integration.  
+You should request the link from the shop owner.  
+If you need more help, don't hesitate to [contact us](mailto:<%= settings.analytics_email %>).

--- a/source/localizable/analytics/index.html.md.erb
+++ b/source/localizable/analytics/index.html.md.erb
@@ -16,6 +16,12 @@ To successfully report your sales insights you have to:
 1. Integrate the Analytics Tracking Script into your website
 2. Declare <%= link_to 'Ecommerce', 'ecommerce' %> actions to report your data
 
+> ##### Note
+> To validate that the script is sending data properly, we offer a developer page with info about the reported data.  
+> Request the link from the shop owner.  
+>
+> **Important**: *That link will be accessible only during the testing phase of integration.*
+
 ### Step 1: Integrate the Analytics Tracking Script
 
 Add the following snippet just before closing either the `<head>` or `<body>` section in all of your website template


### PR DESCRIPTION
Inform Integrators for the provided verification link during analytics testing phase of integration.

<img width="921" alt="screen shot 2015-12-02 at 3 15 44 pm" src="https://cloud.githubusercontent.com/assets/6030161/11531728/9f1de92c-9907-11e5-8df3-66933f49ffe6.png">
---------------------------
<img width="888" alt="screen shot 2015-12-02 at 3 15 53 pm" src="https://cloud.githubusercontent.com/assets/6030161/11531730/9f3a7290-9907-11e5-9c26-9977df2686f4.png">