### PR TITLE
Add link to API access form

### DIFF
--- a/data/alve.yml
+++ b/data/alve.yml
@@ -13,7 +13,7 @@ api_email: 'api@alve.com'
 analytics_email: 'analytics@alve.com'
 
 github_profile: 'https://github.com/skroutz'
-apiv3_early_access_form: 'http://docs.google.com/forms/d/1mUk6pvAXR7yiMqtau8FWnBFamKCY320fL70El_RgN68/viewform'
+api_access_form: 'http://skroutz.it/API_access'
 
 # External Services
 google_analytics_code: 'UA-31711644-1'

--- a/data/docs.yml
+++ b/data/docs.yml
@@ -1,6 +1,7 @@
 apiv3:
   base: '/api/v3/'
   featured: true
+  request_form: true
   icon: 'fa-code'
   pages:
     - { title: 'overview', url: '/api/v3/' }

--- a/data/scrooge.yml
+++ b/data/scrooge.yml
@@ -13,7 +13,7 @@ api_email: 'api@scrooge.co.uk'
 analytics_email: 'analytics@scrooge.co.uk'
 
 github_profile: 'https://github.com/skroutz'
-apiv3_early_access_form: 'http://docs.google.com/forms/d/1mUk6pvAXR7yiMqtau8FWnBFamKCY320fL70El_RgN68/viewform'
+api_access_form: 'http://skroutz.it/API_access'
 
 # External Services
 google_analytics_code: 'UA-48017177-1'

--- a/data/skroutz.yml
+++ b/data/skroutz.yml
@@ -13,7 +13,7 @@ api_email: 'api@skroutz.gr'
 analytics_email: 'analytics@skroutz.gr'
 
 github_profile: 'https://github.com/skroutz'
-apiv3_early_access_form: 'http://docs.google.com/forms/d/1mUk6pvAXR7yiMqtau8FWnBFamKCY320fL70El_RgN68/viewform'
+api_access_form: 'http://skroutz.it/API_access'
 
 # External Services
 google_analytics_code: 'UA-55357-1'

--- a/locales/el.yml
+++ b/locales/el.yml
@@ -15,6 +15,7 @@ el:
   docs:
     index:
       view_doc: 'View Documentation'
+      request_access: 'Request Access'
     apiv3:
       short_description: 'The official %{flavor} API. Access the huge %{flavor} database and create beautiful apps.'
       overview: 'Overview'

--- a/locales/el.yml
+++ b/locales/el.yml
@@ -32,7 +32,6 @@ el:
       favorites: 'User Favorites'
       notifications: 'User Notifications'
       troubleshooting: 'Troubleshooting'
-      early_access: 'Early Access Request'
     apiv2:
       short_description: 'Oldie but still goldie. API v2 is deprecated and should not be used for new applications.'
       overview: 'Overview'

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -35,7 +35,6 @@ en:
       favorites: 'User Favorites'
       notifications: 'User Notifications'
       troubleshooting: 'Troubleshooting'
-      early_access: 'Early Access Request'
     apiv2:
       short_description: 'Oldie but still goldie. API v2 is deprecated and should not be used for new applications.'
       overview: 'Overview'

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -17,6 +17,7 @@ en:
   docs:
     index:
       view_doc: 'View Documentation'
+      request_access: 'Request Access'
     apiv3:
       short_description: 'The official %{flavor} API. Access the huge %{flavor} database and create beautiful apps.'
       overview: 'Overview'

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -15,6 +15,7 @@ tr:
   docs:
     index:
       view_doc: 'View Documentation'
+      request_access: 'Request Access'
     apiv3:
       short_description: 'The official %{flavor} API. Access the huge %{flavor} database and create beautiful apps.'
       overview: 'Overview'

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -32,7 +32,6 @@ tr:
       favorites: 'User Favorites'
       notifications: 'User Notifications'
       troubleshooting: 'Troubleshooting'
-      early_access: 'Early Access Request'
     apiv2:
       short_description: 'Oldie but still goldie. API v2 is deprecated and should not be used for new applications.'
       overview: 'Overview'

--- a/source/assets/stylesheets/pages/_docs.scss
+++ b/source/assets/stylesheets/pages/_docs.scss
@@ -68,7 +68,6 @@
     }
 
     a.goto {
-      display: block;
       font-size: 14px;
     }
   }

--- a/source/localizable/api/v3/shop.html.md.erb
+++ b/source/localizable/api/v3/shop.html.md.erb
@@ -17,6 +17,11 @@ title: shop
 
 ## Retrieve a shop's reviews
 
+### Linked resources
+
+* <%= link_to 'Linked Resources', '/api/v3#linked-resources' %>
+  * <%= link_to 'User', '/api/v3/user' %>
+
 <pre class="terminal">
   GET /shops/:id/reviews
 </pre>

--- a/source/localizable/authorization/index.html.md.erb
+++ b/source/localizable/authorization/index.html.md.erb
@@ -27,7 +27,7 @@ to privileged user owned resources.
 Before you begin the authorization process make sure you have obtained a valid 
 set of `client_id`, `client_secret`.
 
-To get one [contact us](mailto:<%= settings.api_email %>).
+To get one [fill out our request form](<%= settings.api_access_form %>).
 
 Now let's try something that requires authorization.
 

--- a/source/localizable/docs.html.erb
+++ b/source/localizable/docs.html.erb
@@ -21,6 +21,10 @@ title: docs
           </h3>
          <p class="description"><%= t("docs.#{key}.short_description", flavor: settings.site_name.titleize) %></p>
          <%= link_to t('docs.index.view_doc'), doc.base, class: 'goto' %>
+         <% if doc.request_form %>
+           ::
+           <%= link_to t('docs.index.request_access'), settings.api_access_form, class: 'goto' %>
+         <% end %>
         </div>
       </div>
     </div>

--- a/source/localizable/support.html.md.erb
+++ b/source/localizable/support.html.md.erb
@@ -17,7 +17,7 @@ I found a typo in the documentation. What do I do?
 ### API
 
 How do I obtain OAuth credentials?
-: Send us an email at <<%= settings.api_email %>>.
+: [Fill out our request form](<%= settings.api_access_form %>).
 
 How do I access X resource?
 : Read our <%= link_to 'API documentation', '/api/v3' %> thoroughly.


### PR DESCRIPTION
We created a new google form to help us gather data about an API request without requiring the constant exchange of emails to get more info.

We replace the email with the form link in some cases (not all) and also added it in the following spot:

![](http://i.imgur.com/aQYb19z.png)