### PR TITLE
Hide Scrooge Analytics and related Services

### DIFF
--- a/data/docs.yml
+++ b/data/docs.yml
@@ -69,3 +69,6 @@ partner_badge:
   base: '/partner_badge/'
   featured: true
   icon: 'fa-trophy'
+  flavors:
+    - skroutz
+    - alve

--- a/data/docs.yml
+++ b/data/docs.yml
@@ -61,6 +61,9 @@ order_stash:
   base: '/order_stash/'
   featured: true
   icon: 'fa-shopping-basket'
+  flavors:
+    - skroutz
+    - alve
 
 partner_badge:
   base: '/partner_badge/'

--- a/data/docs.yml
+++ b/data/docs.yml
@@ -53,6 +53,9 @@ analytics:
     - { title: 'libraries' }
     - { title: 'examples' }
     - { title: 'faq' }
+  flavors:
+    - skroutz
+    - alve
 
 order_stash:
   base: '/order_stash/'


### PR DESCRIPTION
Show `Analytics`, `OrderStash` and `Partner Badge` only in Skroutz and Alve flavor.