### PR TITLE
Include clarification for field `color` in Greek feedspec

### DIFF
--- a/source/localizable/feedspec/index.el.html.md.erb
+++ b/source/localizable/feedspec/index.el.html.md.erb
@@ -177,10 +177,11 @@ ImageBot v1".
 [Weight](#weight)                                      | Decimal | <span class="mono">-</span>    | Όχι**       | `3200`
 [InStock](#instock)                                    | List    | <span class="mono">-</span>    | Όχι         | `Y`
 [Shipping Costs](#shipping-costs)                      | Decimal | <span class="mono">-</span>    | Όχι         | `3.22`
-[Color](#color)                                        | String  | <span class="mono">100</span>  | Όχι         | `Μαύρο`
+[Color](#color)                                        | String  | <span class="mono">100</span>  | Όχι***      | `Μαύρο`
 
 <small>* Υποχρεωτικό για τις κατηγορίες μόδας όπου υπάρχουν νούμερα, επιπρόσθετες εικόνες</small><br />
-<small>** Υποχρεωτικό για τα καταστήματα που χρησιμοποιούν κανόνες βάρους για τον υπολογισμό των μεταφορικών τους</small>
+<small>** Υποχρεωτικό για τα καταστήματα που χρησιμοποιούν κανόνες βάρους για τον υπολογισμό των μεταφορικών τους</small><br />
+<small>*** Υποχρεωτικό για όλες τις κατηγορίες μόδας</small>
 
 
 #### Unique ID


### PR DESCRIPTION
In the English version of the feedspec, the field `color` notes that it's required for any fashion item. The Greek feedspec, however, doesn't include such a note. This PR addresses this mismatch by including the same note (translated) in the Greek feedspec.