### PR TITLE
Marketplace line item extra

### DIFF
--- a/source/localizable/smart_cart/_order_object.html.md.erb
+++ b/source/localizable/smart_cart/_order_object.html.md.erb
@@ -1,7 +1,7 @@
 #### Order object
 
 Name         | Type   | Value | Description
-:------------: | :-------: |  | :---------------:
+------------ | ------ | ----- | -----------------
 `code`       | String | | Order code
 `state`      | String | `open`, `accepted`, `rejected`, `cancelled`, `expired`,<br> `dispatched`, `delivered`, `partially_returned`, `returned` | Order state
 `customer`   | Object | | [Customer details](#customer-details)
@@ -21,7 +21,7 @@ Name         | Type   | Value | Description
 #### Customer details
 
 Name                              | Type   | Description
-:-------------------------------: | :----: | :------------------------------------------:
+--------------------------------- | ------ | --------------------------------------------
 `customer.id`                     | String |Unique customer id
 `customer.first_name`             | String |First name
 `customer.last_name`              | String |Last name
@@ -30,7 +30,7 @@ Name                              | Type   | Description
 #### Customer shipping address
 
 Name                                            | Type    | Description
-:---------------------------------------------: | :-----: | :------------------------------------------:
+----------------------------------------------- | ------- | --------------------------------------------
 `customer.address.street_name`                  | String  | Address street
 `customer.address.street_number`                | String  | Address number
 `customer.address.zip`                          | String  | Address postal code
@@ -44,7 +44,7 @@ Name                                            | Type    | Description
 This attribute is present only when a user requests an invoice for the order.
 
 Name                                           | Type    | Description
-:--------------------------------------------: | :-----: | :----------------------------------------------:
+---------------------------------------------- | ------- | ------------------------------------------------
 `invoice_details.company`                      | String  | Company's name
 `invoice_details.profession`                   | String  | Company's profession
 `invoice_details.vat_number`                   | String  | Company's VAT number
@@ -56,7 +56,7 @@ Name                                           | Type    | Description
 #### Billing address
 
 Name                                     | Type   | Description
-:--------------------------------------: | :----: | :------------------------------------------:
+---------------------------------------- | ------ | --------------------------------------------
 `invoice_details.address.street_name`    | String | Address street
 `invoice_details.address.street_number`  | String | Address number
 `invoice_details.address.zip`            | String | Address postal code
@@ -66,7 +66,7 @@ Name                                     | Type   | Description
 #### Vat exclusion representative
 
 Name                                                      | Type   | Description
-:-------------------------------------------------------: | :----: | :----------------------------------------------:
+--------------------------------------------------------- | ------ | ------------------------------------------------
 `invoice_details.vat_exclusion_representative.id_type`    | String | Provided ID document type
 `invoice_details.vat_exclusion_representative.id_number`  | String | Provided ID document number (last 5 digits)
 `invoice_details.vat_exclusion_representative.otp`        | String | Provided representative one-time password
@@ -74,7 +74,7 @@ Name                                                      | Type   | Description
 #### Order line items array
 
 Name                              | Type      | Description
-:-------------------------------: | :-------: | :----------------------------------------------:
+--------------------------------- | --------- | ------------------------------------------------
 `line_items[_].id`              | String  | Unique item id
 `line_items[_].shop_uid`        | String  | Item id in shop
 `line_items[_].product_name`    | String  | Item product name
@@ -89,7 +89,7 @@ Name                              | Type      | Description
 #### Line item size
 
 Name                              | Type   | Value | Description
-:-------------------------------: | :----: | :---: | :------------------------------------------:
+--------------------------------- | ------ | ----- | --------------------------------------------
 `line_items[_].size.label`        | String | `Νούμερο`, `Μέγεθος`, `Ηλικία` |Item size label
 `line_items[_].size.value`        | String |    |Item size value
 `line_items[_].size.shop_value`   | String |    |Item original size as provided by the shop
@@ -101,7 +101,7 @@ These are valid values to POST to the corresponding keys when
 (only available for orders with state `"open"`).
 
 Name                              | Type   | Example     | Description
-:-------------------------------: | :----: | :---------: | :------------------------------------------------:
+--------------------------------- | ------ | ----------- | --------------------------------------------------
 `accept_options.number_of_parcels`| Array  | `[1, 2, 3]` | Valid values to post on `number_of_parcels`
 `accept_options.pickup_location`  | Array  |             | [Pickup location](#accept-option-pickup-location)
 `accept_options.pickup_window`    | Array  |             | [Pickup window](#accept-option-pickup-window)
@@ -112,7 +112,7 @@ Valid pickup locations to post when
 [accepting a single order](/smart_cart/orders_api/#accept-a-single-order) (use `id`).
 
 Name                    | Type    | Description
-:---------------------: | :-----: | :-----------------------:
+----------------------- | ------- | -------------------------
 `pickup_location.id`    | String  | The location ID to use
 `pickup_location.label` | String  | A human readable address
 
@@ -122,7 +122,7 @@ Valid pickup windows to post when
 [accepting a single order](/smart_cart/orders_api/#accept-a-single-order) (use `id`).
 
 Name                    | Type    | Description
-:---------------------: | :-----: | :--------------------------:
+----------------------- | ------- | ----------------------------
 `pickup_window.id`      | Integer | The pickup window ID to use
 `pickup_window.label`   | String  | A human readable time range
 
@@ -134,7 +134,7 @@ These are possible values to POST to the corresponding keys when
 (only available for orders with state `"open"`).
 
 Name                                         | Type   | Description
-:------------------------------------------: | :----: | :----------------------------------------------------------------------:
+-------------------------------------------- | ------ | ------------------------------------------------------------------------
 `reject_options.line_item_rejection_reasons` | Array  | [Line item rejection reason](#reject-option-line-item-rejection-reason)
 
 #### Reject option: Line item rejection reason
@@ -143,7 +143,7 @@ Available reasons to post along line_item ids when
 [rejecting a single order](/smart_cart/orders_api/#reject-a-single-order) (use `id`).
 
 Name                                                       | Type    | Description
-:--------------------------------------------------------: | :-----: | :----------------------------------------------:
+---------------------------------------------------------- | ------- | ------------------------------------------------
 `line_item_rejection_reason.id`                            | Integer | The rejection reason ID to use
 `line_item_rejection_reason.label`                         | String  | A human readable label
 `line_item_rejection_reason.requires_available_quantity`   | Boolean | Whether or not `available_quantity` is required
@@ -151,7 +151,7 @@ Name                                                       | Type    | Descripti
 Possible values
 
 ID    | Label                                               | Requires Available Quantity
-:---: | :-------------------------------------------------: | :--------------------------:
+----- | --------------------------------------------------- | ----------------------------
 `1`   | `Εκτός αποθέματος στο κατάστημα ή στον προμηθευτή`  | False
 `2`   | `Λάθος καταχωρημένη τιμή(ες)`                       | False
 `4`   | `Περιορισμένα τεμάχια`                              | True

--- a/source/localizable/smart_cart/_order_object.html.md.erb
+++ b/source/localizable/smart_cart/_order_object.html.md.erb
@@ -84,6 +84,7 @@ Name                              | Type      | Description
 `line_items[_].total_price`     | Double  | Total item price in euros: `unit_price` * `quantity`
 `line_items[_].price_includes_vat` | Boolean  | Price includes VAT (could be `false` for [invoice](#invoice-details) with VAT exclusion)
 `line_items[_].ean`             | String  | EAN code of product (optional)
+`line_items[_].extra_info`      | String  | Additional information for item, eg. color preference or prescription details for contact lenses (optional) [webhook example](../webhook/#example-9-with-extrainfo-in-lineitems)
 
 #### Line item size
 

--- a/source/localizable/smart_cart/webhook.html.md.erb
+++ b/source/localizable/smart_cart/webhook.html.md.erb
@@ -980,3 +980,110 @@ Name           | Type   | Value | Description
   }
 }
 ~~~
+
+#### Example 9 (with extra_info in line_items)
+
+~~~ json
+{
+  "event_type": "new_order",
+  "event_time": "2019-11-28T13:24:37+02:00",
+  "order": {
+    "code": "191029-5130474",
+    "state": "open",
+    "customer": {
+      "id": "PA4oqvpz8x",
+      "first_name": "John",
+      "last_name": "Doe",
+      "address":{
+        "street_name":"Πανεπιστημίου",
+        "street_number":"4",
+        "zip":"12345",
+        "city":"Αθήνα",
+        "region":"Αττικής",
+        "pickup_from_collection_point": false
+      }
+    },
+    "invoice": false,
+    "comments": "Παράδοση στο γραφείο",
+    "courier": "ACS",
+    "courier_voucher": null,
+    "courier_tracking_codes": [],
+    "line_items": [
+      {
+        "id": "RPJJ8gG5Pg",
+        "shop_uid": "768",
+        "product_name": "AIR OPTIX COLORS MHNIAIOI",
+        "quantity": 2,
+        "unit_price": 25.5,
+        "total_price": 51,
+        "price_includes_vat": true,
+        "extra_info": "Χρώμα: Πράσινο\nΒαθμοί SPH: -6.50"
+      }
+    ],
+    "created_at": "2019-11-28T13:24:37+02:00",
+    "expires_at": "2019-12-04T10:24:00+02:00",
+    "dispatch_until": "2019-12-04T18:00:00+02:00",
+    "accept_options": {
+      "number_of_parcels": [
+        1
+      ],
+      "pickup_location": [
+        {
+          "id": "YlpD0KROym",
+          "label": "Πανεπιστημίου 2, Τ.Κ. 12345, Αθήνα, Αττική"
+        },
+        {
+          "id": "onpL6DXG4l",
+          "label": "Σταδίου 1, Τ.Κ. 12345, Αθήνα, Αττική"
+        },
+        {
+          "id": "wgO1N22OaQ",
+          "label": "Κρήτης 50, Τ.Κ. 73100, Χανιά, Χανιά"
+        }
+      ],
+      "pickup_window": [
+        {
+          "id": 1,
+          "label": "15:00 - 18:00, Τρί 03/12/19"
+        },
+        {
+          "id": 2,
+          "label": "10:00 - 12:00, Τετ 04/12/19"
+        },
+        {
+          "id": 3,
+          "label": "12:00 - 15:00, Τετ 04/12/19"
+        },
+        {
+          "id": 4,
+          "label": "15:00 - 18:00, Τετ 04/12/19"
+        }
+      ]
+    },
+    "reject_options": {
+      "line_item_rejection_reasons": [
+        {
+          "id": 1,
+          "label": "Εκτός αποθέματος στο κατάστημα ή στον προμηθευτή",
+          "requires_available_quantity": false
+        },
+        {
+          "id": 2,
+          "label": "Λάθος καταχωρημένη τιμή(ες)",
+          "requires_available_quantity": false
+        },
+        {
+          "id": 4,
+          "label": "Περιορισμένα τεμάχια",
+          "requires_available_quantity": true
+        },
+        {
+          "id": 5,
+          "label": "To προϊόν καταργήθηκε",
+          "requires_available_quantity": false
+        }
+      ]
+    }
+  }
+}
+~~~

--- a/source/localizable/smart_cart/webhook.html.md.erb
+++ b/source/localizable/smart_cart/webhook.html.md.erb
@@ -88,7 +88,7 @@ event notification is sent for the following cases:
 #### Request payload
 
 Name           | Type   | Value | Description
-:------------: | :----: | :---: | :----------------:
+-------------- | ------ | ----- | ------------------
 `event_type`   | String | `new_order`, `order_updated`| Order event type
 `event_time`   | Date String in format<br> `YYYY-MM-DDTHH:MM:SS+HH:M` | | Event creation time
 `order`        | Object |            | [Order details](#order-object)
@@ -97,7 +97,7 @@ Name           | Type   | Value | Description
 #### Order changes object
 
 Name           | Type   | Value | Description
-:------------: | :----: | :---: | :-----------:
+-------------- | ------ | ----- | -------------
 `state` | Object | `{ "old": "open", "new": "cancelled" }` | The state changed values (optional)
 `expires_at` | Object | `{ "old": "2019-11-02T13:15:43+02:00", "new": "2019-11-04T13:15:00+02:00" }` | The order's current expiration time changes (optional)
 `dispatch_until` | Object | `{ "old": "2019-11-03T12:00:00+02:00", "new": "2019-11-04T18:00:00+02:00" }` | The order's current time until dispatching changes (optional)


### PR DESCRIPTION
Adds a description about `extra_info` in marketplace order's `line_items`, along with an example payload in Webhook.

It also removes center alignment from tables. 