### PR TITLE
Fix typo in /user/saved_orders endpoint

### DIFF
--- a/resources/responses/skroutz/user_saved_orders.yml
+++ b/resources/responses/skroutz/user_saved_orders.yml
@@ -1,6 +1,6 @@
 ---
 :request:
-  :url: http://api.skroutz.gr/api/user/saved_orders
+  :url: https://api.skroutz.gr/user/saved_orders
   :headers:
     :accept: application/vnd.skroutz+json; version=3.1
     :authorization: Bearer h2GTSZPqbSc7bKiyYS1j3gNd_1PoNDBLNQzdCgnBonNmTZ9r8eRMBMe-SvM8waex8TRa5kFU_Wn5bffjEZwQew==


### PR DESCRIPTION
The purpose of this PR is to fix two minor typos in `/user/saved_orders` endpoint:

 - `https` instead of `http`
 - remove unnecessary `/api` prefix from resource path