### PR TITLE
Remove cancellation order update case

### DIFF
--- a/source/localizable/smart_cart/webhook.html.md.erb
+++ b/source/localizable/smart_cart/webhook.html.md.erb
@@ -84,7 +84,6 @@ A **new order** webhook request is triggered upon the placement of a new order.
 An **order update** event is triggered upon the update of an order. As of right now, an update
 event notification is sent for the following cases:
 
-* When an order is **cancelled** (either by the user or our support team).
 * When an order is **extended** (allowing more time to handle the order).
 * When an order's courier voucher is **created** (for the associated shipment).
 * **From 5/7/2021 onwards**: When an order's **[state](/smart_cart/orders_api#order-object-attributes-appendix) is changed** (either by user, our support team, or the merchant)


### PR DESCRIPTION
Since we have introduced order updates for all state changes as described by the last bullet, there's no need to explicitly mention cancellation. Extension makes sense to remain as is as there's no explicit state to describe this.