### PR TITLE
Marketplace/add fbs delivery note attr to order

### DIFF
--- a/resources/responses/skroutz/merchants_ecommerce_orders_demo_accepted.yml
+++ b/resources/responses/skroutz/merchants_ecommerce_orders_demo_accepted.yml
@@ -92,6 +92,7 @@
     "dispatch_until": "2021-06-28T13:11:41+03:00",
     "express": false,
     "gift_wrap": false,
-    "fulfilled_by_skroutz": false
+    "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null
   }
 }'

--- a/resources/responses/skroutz/merchants_ecommerce_orders_demo_fbs.yml
+++ b/resources/responses/skroutz/merchants_ecommerce_orders_demo_fbs.yml
@@ -92,6 +92,7 @@
     "dispatch_until": "2021-06-28T13:11:41+03:00",
     "express": false,
     "gift_wrap": false,
-    "fulfilled_by_skroutz": true
+    "fulfilled_by_skroutz": true,
+    "fbs_delivery_note: null
   }
 }'

--- a/resources/responses/skroutz/merchants_ecommerce_orders_demo_fbs_dispatched.yml
+++ b/resources/responses/skroutz/merchants_ecommerce_orders_demo_fbs_dispatched.yml
@@ -1,0 +1,98 @@
+---
+:request:
+  :url: https://api.skroutz.gr/merchants/ecommerce/orders/DEMO-FBS-DISPATCHED
+  :headers:
+    :accept: application/vnd.skroutz+json; version=3.0
+    :authorization: Bearer n4_92SD9EAEkwDfgiYZHiWwSdJlmA5q-_H3FQ6iYZ3jcMynhbpLEe3QvZxrvO0D-8ZYYD2n_wOBexdn9B0NYGQ==
+  :verb: :get
+:response:
+  :status: 200
+  :headers:
+    Date: Thu, 24 Jun 2021 15:01:26 GMT
+    Connection: keep-alive
+    Content-Length: 6400
+    Server: h2o (Debian)
+    Content-Type: application/json; charset=utf-8
+    X-Meta-Client-Id: 27951bdf06a65ea4
+    Cache-Control: no-cache
+    X-Request-Id: 989369834
+    X-Runtime: 0.021923
+    X-App: as103_ssl
+    X-Varnish: 989369834
+    Age: 0
+    Via: 1.1 varnish (Varnish/5.0)
+    X-Origin: lb2
+    X-Cache: MISS
+    X-Cached: skroutz miss(0)
+  :body: '{
+  "order": {
+    "code": "DEMO-FBS-DISPATCHED",
+    "state": "dispatched",
+    "customer": {
+      "id": "user1234",
+      "first_name": "John",
+      "last_name": "Doe",
+      "address": {
+        "street_name": "Πανεπιστημίου",
+        "street_number": "4",
+        "zip": "12345",
+        "city": "Αθήνα",
+        "region": "Αττικής",
+        "pickup_from_collection_point": false
+      }
+    },
+    "invoice": false,
+    "comments": "Παράδοση στο γραφείο",
+    "courier": "CourierCenter",
+    "courier_voucher": null,
+    "courier_tracking_codes": [
+      "123456789"
+    ],
+    "line_items": [
+      {
+        "id": "Y5jVmgKmeX",
+        "shop_uid": "405753",
+        "product_name": "Adidas Perormance Badge of Sport Swimsuit PS/GS",
+        "quantity": 2,
+        "size": {
+          "label": "Ηλικία",
+          "value": "14 χρονών",
+          "shop_value": "12-14"
+        },
+        "unit_price": 17.99,
+        "total_price": 35.98,
+        "price_includes_vat": true,
+        "ean": "1234567890123",
+        "serial_numbers": null
+      },
+      {
+        "id": "3XlV8ebjxm",
+        "shop_uid": "10",
+        "product_name": "Smartphone 123",
+        "quantity": 2,
+        "unit_price": 100,
+        "total_price": 200,
+        "price_includes_vat": true,
+        "serial_numbers": "SN12345,SN56789"
+      },
+      {
+        "id": "ZvEKMxbxr1",
+        "shop_uid": "768",
+        "product_name": "AIR OPTIX COLORS MHNIAIOI",
+        "quantity": 2,
+        "unit_price": 25.5,
+        "total_price": 51,
+        "price_includes_vat": true,
+        "extra_info": "Χρώμα: Πράσινο\\nΒαθμοί SPH: -6.50",
+        "serial_numbers": null
+      }
+    ],
+    "created_at": "2021-06-24T13:11:41+03:00",
+    "expires_at": "2021-06-25T13:11:41+03:00",
+    "dispatch_until": "2021-06-28T13:11:41+03:00",
+    "express": false,
+    "gift_wrap": false,
+    "fulfilled_by_skroutz": true,
+    "fbs_delivery_note: "ΤΛΑΠΟ0454022"
+  }
+}'

--- a/resources/responses/skroutz/merchants_ecommerce_orders_demo_invoice.yml
+++ b/resources/responses/skroutz/merchants_ecommerce_orders_demo_invoice.yml
@@ -105,6 +105,7 @@
     "express": false,
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
+    "fbs_delivery_note: null,
     "accept_options": {
       "number_of_parcels": [
         1

--- a/resources/responses/skroutz/merchants_ecommerce_orders_demo_invoice39a.yml
+++ b/resources/responses/skroutz/merchants_ecommerce_orders_demo_invoice39a.yml
@@ -113,6 +113,7 @@
     "express": false,
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
         1

--- a/resources/responses/skroutz/merchants_ecommerce_orders_demo_open.yml
+++ b/resources/responses/skroutz/merchants_ecommerce_orders_demo_open.yml
@@ -91,6 +91,7 @@
     "express": false,
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
         1

--- a/resources/responses/skroutz/merchants_ecommerce_orders_demo_rejected.yml
+++ b/resources/responses/skroutz/merchants_ecommerce_orders_demo_rejected.yml
@@ -91,6 +91,7 @@
     "express": false,
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null,
     "rejection_info": {
       "reason": "Το κατάστημά μας είναι κλειστό για προσωπικούς λόγους",
       "actor": "merchant"

--- a/resources/responses/skroutz/merchants_ecommerce_orders_show.yml
+++ b/resources/responses/skroutz/merchants_ecommerce_orders_show.yml
@@ -96,6 +96,7 @@
     "express": false,
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
         1

--- a/source/localizable/smart_cart/_order_object.html.md.erb
+++ b/source/localizable/smart_cart/_order_object.html.md.erb
@@ -21,6 +21,7 @@ Name         | Type   | Value | Description
 `accept_options` | Object | | [Accept options](#accept-options) (available for orders with state `"open"`)
 `reject_options` | Object | | [Reject options](#reject-options) (available for orders with state `"open"`)
 `fulfilled_by_skroutz` | Boolean | | Whether the order is fulfilled by skroutz
+`fbs_delivery_note` | String | | Order's delivery note from warehouse for orders that are fulfilled by Skroutz
 `pickup_window` | Object | | Selected [Pickup window](#pickup-window)
 `pickup_address` | String | | Pickup location address
 `number_of_parcels` | Integer | | Number of parcels
@@ -91,7 +92,7 @@ Name                                                       | Type               
 ---------------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------
 `pickup_window.from`                                       | Date String in format<br> `YYYY-MM-DDTHH:MM:SS+HH:M` | Pickup window starting date/time
 `pickup_window.to`                                         | Date String in format<br> `YYYY-MM-DDTHH:MM:SS+HH:M` | Pickup window ending date/time
- 
+
 #### Order line items array
 
 Name                              | Type      | Description

--- a/source/localizable/smart_cart/orders_api.html.md.erb
+++ b/source/localizable/smart_cart/orders_api.html.md.erb
@@ -250,6 +250,16 @@ An already-accepted order without a courier voucher that will be fulfilled by Sk
 
 <%= render_recording :merchants_ecommerce_orders_demo_fbs %>
 
+#### DEMO-FBS-DISPATCHED
+
+A dispatched order without a courier voucher that will be fulfilled by Skroutz. Delivery note included.
+
+<pre class="terminal">
+  GET /merchants/ecommerce/orders/DEMO-FBS-DISPATCHED
+</pre>
+
+<%= render_recording :merchants_ecommerce_orders_demo_fbs_dispatched %>
+
 ## Order object attributes appendix
 
 > The order object returned retrieving a single order via the API is the same as

--- a/source/localizable/smart_cart/webhook.html.md.erb
+++ b/source/localizable/smart_cart/webhook.html.md.erb
@@ -130,6 +130,7 @@ kinds of Webhook requests** for testing. In the following examples, `:code` shou
 - `DEMO-INVOICE`
 - `DEMO-INVOICE39A`
 - `DEMO-FBS`
+- `DEMO-FBS-DISPATCHED`
 
 An order creation or order update event should be received at the webhook url of the shop, depending on the request action.
 Sending any of the following requests should request in a successful response (`200 OK`):

--- a/source/localizable/smart_cart/webhook.html.md.erb
+++ b/source/localizable/smart_cart/webhook.html.md.erb
@@ -240,6 +240,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "express": false,
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
         1
@@ -368,6 +369,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "express": false,
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null
     "accept_options": {
       "number_of_parcels": [
         1
@@ -490,7 +492,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "dispatch_until": "2019-10-30T15:00:00+02:00"
     "express": false,
     "gift_wrap": false,
-    "fulfilled_by_skroutz": false
+    "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null
   },
   "changes": {
     "state": {
@@ -528,6 +531,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "express": false,
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null,
     "courier": "ACS",
     "courier_voucher": null,
     "courier_tracking_codes": [],
@@ -562,6 +566,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "express": false,
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
         1
@@ -695,6 +700,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "express": false,
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null
     "pickup_window": { from: "2019-11-02T15:00:00+02:00", "to": "2019-11-02T16:00:00+02:00" },
     "number_of_parcels": 1,
     "pickup_address": "Πανεπιστημίου 2, Τ.Κ. 12345, Αθήνα, Αττική"
@@ -753,6 +759,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "express": false,
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null,
     "courier": "ACS",
     "courier_voucher": null,
     "courier_tracking_codes": [],
@@ -787,6 +794,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "express": false,
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
         1
@@ -929,6 +937,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "express": false,
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
         1
@@ -1066,6 +1075,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "express": false,
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
         1
@@ -1189,6 +1199,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "express": false,
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
         1
@@ -1301,6 +1312,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "express": false,
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
+    "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
         1

--- a/source/localizable/smart_cart/webhook.html.md.erb
+++ b/source/localizable/smart_cart/webhook.html.md.erb
@@ -110,6 +110,7 @@ Name           | Type   | Value | Description
 `dispatch_until` | Object | `{ "old": "2019-11-03T12:00:00+02:00", "new": "2019-11-04T18:00:00+02:00" }` | The order's current time until dispatching changes (optional)
 `courier_voucher` | Object | `{ "old": null, "new": "https://b.scdn.gr/path-to/voucher.pdf" }` | The order's shipment courier voucher URL (optional)
 `courier_tracking_codes` | Object | `{ "old": [], "new": ["123456789"] }` | The order's shipment courier tracking codes (optional)
+`fbs_delivery_note` | Object | `{ "old": null, "new": "ΤΛΑΠΟ0454022" }` | The order's fulfilled by Skroutz warehouse delivery note (optional)
 `pickup_window` | Object | `{ "old": null, "new: { from: "2019-11-02T15:00:00+02:00", "to": "2019-11-02T16:00:00+02:00" } }` | The order's shipment pickup window (optional). It is sent when the order is accepted.
 `number_of_parcels` | Integer | `{ "old": null, "new": 2 }` | The order's shipment number of parcels (optional). It is sent when the order is accepted.
 `pickup_address` | String | `{ "old": null, "new": "Πανεπιστημίου 2, Τ.Κ. 12345, Αθήνα, Αττική" }` | The order's pickup address (optional).


### PR DESCRIPTION
Documentation for `fbs_delivery_note` attribute for fulfilled by skroutz orders when dispatched from warehouse