### PR TITLE
Fix documentation for fbs purchase orders index request

### DIFF
--- a/source/localizable/smart_cart/fbs_api.html.md.erb
+++ b/source/localizable/smart_cart/fbs_api.html.md.erb
@@ -59,7 +59,7 @@ curl -X GET https://<%= settings.api_domain %>/merchants/ecommerce/fbs/products 
 
 ### Purchase Orders
 
-#### Retrieve a purchase order
+#### Retrieve purchase orders
 
 To retrieve a shop's Fulfilled by Skroutz purchase orders.
 
@@ -74,7 +74,7 @@ curl -X GET https://<%= settings.api_domain %>/merchants/ecommerce/fbs/purchase_
   -H 'Authorization: Bearer your_access_token_here'
 </pre>
 
-<%= render_recording :merchants_fbs_suppliers_index %>
+<%= render_recording :merchants_fbs_purchase_orders_index %>
 
 #### Create a new purchase order.
 


### PR DESCRIPTION
Implements [T135308](https://phabricator.skroutz.gr/T135308)

**Information**
In https://developer.skroutz.gr/smart_cart/fbs_api/#purchase-orders, the first section refers to an index request but has a wrong example. The title of the section has been changed to `Retrieve purchase orders` and the example is now correctly a get request returning a list of purchase orders.