### PR TITLE
Update webhook documentation for new fields

### DIFF
--- a/source/localizable/smart_cart/_order_object.html.md.erb
+++ b/source/localizable/smart_cart/_order_object.html.md.erb
@@ -112,6 +112,8 @@ Name                              | Type      | Description
 `line_items[_].unit_price`      | Double  | Price per item in euros
 `line_items[_].total_price`     | Double  | Total item price in euros: `unit_price` * `quantity`
 `line_items[_].price_includes_vat` | Boolean  | Price includes VAT (could be `false` for [invoice](#invoice-details) with VAT exclusion)
+`line_items[_].commission`      | Double  | Commission in euros: `total_price` * (`commission_rate`/100)
+`line_items[_].commission_rate` | Double  | Commission rate as percentage, e.g. `8.34`
 `line_items[_].island_vat_discount_applied` | Boolean  | VAT discount applied (could be `true` for [invoice](#invoice-details) orders, billed to customers in [5 specific Greek islands](http://elib.aade.gr/elib/view?d=/gr/ap/2021/A_1150/))
 `line_items[_].ean`             | String  | EAN code of product (optional)
 `line_items[_].extra_info`      | String  | Additional information for item, eg. color preference or prescription details for contact lenses (optional) [webhook example](../webhook/#example-9-with-extrainfo-in-lineitems)

--- a/source/localizable/smart_cart/_order_object.html.md.erb
+++ b/source/localizable/smart_cart/_order_object.html.md.erb
@@ -117,6 +117,7 @@ Name                              | Type      | Description
 `line_items[_].commission_rate` | Double  | Commission rate as percentage, e.g. `8.34`
 `line_items[_].island_vat_discount_applied` | Boolean  | VAT discount applied (could be `true` for [invoice](#invoice-details) orders, billed to customers in [5 specific Greek islands](http://elib.aade.gr/elib/view?d=/gr/ap/2021/A_1150/))
 `line_items[_].ean`             | String  | EAN code of product (optional)
+`line_items[_].mpn`             | String  | MPN code of product (optional)
 `line_items[_].extra_info`      | String  | Additional information for item, eg. color preference or prescription details for contact lenses (optional) [webhook example](../webhook/#example-9-with-extrainfo-in-lineitems)
 `line_items[_].rejection_reason` | String | Rejection reason (possible values: `limited_stock`, `no_stock`, `discontinuation`, `wrong_price`)
 `line_items[_].return_reason` | String | User return reason (possible values: `faulty`, `wrong_product`, `withdrawal`, `wrong_size`)
@@ -131,6 +132,7 @@ Name                              | Type   | Value | Description
 `line_items[_].size.shop_value`   | String |    |Item original size as provided by the shop
 `line_items[_].size.shop_variation_uid` | String | | Variation ID in shop for an item
 `line_items[_].size.ean`          | String | | EAN code of variation
+`line_items[_].size.mpn`          | String | | MPN code of variation
 
 #### Accept options
 

--- a/source/localizable/smart_cart/_order_object.html.md.erb
+++ b/source/localizable/smart_cart/_order_object.html.md.erb
@@ -122,6 +122,7 @@ Name                              | Type      | Description
 `line_items[_].rejection_reason` | String | Rejection reason (possible values: `limited_stock`, `no_stock`, `discontinuation`, `wrong_price`)
 `line_items[_].return_reason` | String | User return reason (possible values: `faulty`, `wrong_product`, `withdrawal`, `wrong_size`)
 `line_items[_].serial_numbers` | String | Serial numbers for item, concatenated by ',', e.g. `SN12345,SN56789`
+`line_items[_].tags` | Array | A list of tags that characterize the line item (optional). Supported tags: `["plus_deal"]`
 
 #### Line item size
 

--- a/source/localizable/smart_cart/_order_object.html.md.erb
+++ b/source/localizable/smart_cart/_order_object.html.md.erb
@@ -24,6 +24,7 @@ Name         | Type   | Value | Description
 `fbs_delivery_note` | String | | Order's delivery note from warehouse for orders that are fulfilled by Skroutz
 `store_pickup` | Boolean | | Whether the order will be picked up by the user at the store
 `shipping_cost` | Double | | The order's shipping cost in euros (only available for FBM (Fulfilled By Merchant) orders)
+`commission`  | Double | | Order's total commission in euros
 `pickup_window` | Object | | Selected [Pickup window](#pickup-window)
 `pickup_address` | String | | Pickup location address
 `number_of_parcels` | Integer | | Number of parcels

--- a/source/localizable/smart_cart/webhook.html.md.erb
+++ b/source/localizable/smart_cart/webhook.html.md.erb
@@ -226,6 +226,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
+        "mpn": "JA-1059",
         "serial_numbers": null
       },
       {
@@ -356,7 +357,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
             "value": "14 χρονών",
             "shop_value": "12-14",
             "shop_variation_uid": "40575312-14",
-            "ean": "1234567890321"
+            "ean": "1234567890321",
+            "mpn": "JA-1059"
         },
         "unit_price": 17.99,
         "total_price": 35.98,
@@ -365,6 +367,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
+        "mpn": "JA-1059",
         "serial_numbers": null
       },
       {
@@ -496,6 +499,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
+        "mpn": "JA-1059",
         "serial_numbers": null
       },
       {
@@ -577,6 +581,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
+        "mpn": "JA-1059",
         "serial_numbers": null
       },
       {
@@ -718,6 +723,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
+        "mpn": "JA-1059",
         "serial_numbers": null
       },
       {
@@ -820,6 +826,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
+        "mpn": "JA-1059",
         "serial_numbers": null
       },
       {
@@ -973,6 +980,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
+        "mpn": "JA-1059",
         "serial_numbers": null
       },
       {
@@ -1118,6 +1126,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "commission_rate": 8.34,
         "island_vat_discount_applied": true,
         "ean": "1234567890123",
+        "mpn": "JA-1059",
         "serial_numbers": null
       },
       {
@@ -1498,6 +1507,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
+        "mpn": "JA-1059",
         "serial_numbers": null
       },
       {

--- a/source/localizable/smart_cart/webhook.html.md.erb
+++ b/source/localizable/smart_cart/webhook.html.md.erb
@@ -222,6 +222,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 10.40,
         "total_price": 20.80,
         "price_includes_vat": true,
+        "commission": 1.73,
+        "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
         "serial_numbers": null
@@ -234,6 +236,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 25,
         "total_price": 25,
         "price_includes_vat": true,
+        "commission": 2.32,
+        "commission_rate": 9.28,
         "island_vat_discount_applied": false,
         "serial_numbers": null
       }
@@ -356,6 +360,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 17.99,
         "total_price": 35.98,
         "price_includes_vat": true,
+        "commission": 3.00,
+        "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
         "serial_numbers": null
@@ -368,6 +374,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 25,
         "total_price": 25,
         "price_includes_vat": true,
+        "commission": 2.32,
+        "commission_rate": 9.28,
         "island_vat_discount_applied": false,
         "serial_numbers": null
       }
@@ -482,6 +490,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 10.40,
         "total_price": 20.80,
         "price_includes_vat": true,
+        "commission": 1.73,
+        "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
         "serial_numbers": null
@@ -494,6 +504,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 25,
         "total_price": 25,
         "price_includes_vat": true,
+        "commission": 2.32,
+        "commission_rate": 9.28,
         "island_vat_discount_applied": false,
         "serial_numbers": null
       }
@@ -558,6 +570,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 10.40,
         "total_price": 20.80,
         "price_includes_vat": true,
+        "commission": 1.73,
+        "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
         "serial_numbers": null
@@ -570,6 +584,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 25,
         "total_price": 25,
         "price_includes_vat": true,
+        "commission": 2.32,
+        "commission_rate": 9.28,
         "island_vat_discount_applied": false,
         "serial_numbers": null
       }
@@ -694,6 +710,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 10.40,
         "total_price": 20.80,
         "price_includes_vat": true,
+        "commission": 1.73,
+        "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
         "serial_numbers": null
@@ -706,6 +724,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 25,
         "total_price": 25,
         "price_includes_vat": true,
+        "commission": 2.32,
+        "commission_rate": 9.28,
         "island_vat_discount_applied": false,
         "serial_numbers": null
       }
@@ -791,6 +811,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 10.40,
         "total_price": 20.80,
         "price_includes_vat": true,
+        "commission": 1.73,
+        "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
         "serial_numbers": null
@@ -803,6 +825,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 25,
         "total_price": 25,
         "price_includes_vat": true,
+        "commission": 2.32,
+        "commission_rate": 9.28,
         "island_vat_discount_applied": false,
         "serial_numbers": null
       }
@@ -939,6 +963,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 100,
         "total_price": 200,
         "price_includes_vat": false,
+        "commission": 16.68,
+        "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
         "serial_numbers": null
@@ -951,6 +977,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 25,
         "total_price": 25,
         "price_includes_vat": true,
+        "commission": 2.32,
+        "commission_rate": 9.28,
         "island_vat_discount_applied": false,
         "serial_numbers": null
       }
@@ -1079,6 +1107,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 100,
         "total_price": 200,
         "price_includes_vat": true,
+        "commission": 16.68,
+        "commission_rate": 8.34,
         "island_vat_discount_applied": true,
         "ean": "1234567890123",
         "serial_numbers": null
@@ -1091,6 +1121,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 25,
         "total_price": 25,
         "price_includes_vat": true,
+        "commission": 2.32,
+        "commission_rate": 9.28,
         "island_vat_discount_applied": false,
         "serial_numbers": null
       }
@@ -1206,6 +1238,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 10.40,
         "total_price": 20.80,
         "price_includes_vat": true,
+        "commission": 1.73,
+        "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "serial_numbers": null
       },
@@ -1217,6 +1251,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 25,
         "total_price": 25,
         "price_includes_vat": true,
+        "commission": 2.32,
+        "commission_rate": 9.28,
         "island_vat_discount_applied": false,
         "serial_numbers": null
       }
@@ -1331,6 +1367,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 25.5,
         "total_price": 51,
         "price_includes_vat": true,
+        "commission": 4.73,
+        "commission_rate": 9.28,
         "island_vat_discount_applied": false,
         "extra_info": "Χρώμα: Πράσινο\nΒαθμοί SPH: -6.50",
         "serial_numbers": null
@@ -1446,6 +1484,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 10.40,
         "total_price": 20.80,
         "price_includes_vat": true,
+        "commission": 1.73,
+        "commission_rate": 8.34,
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
         "serial_numbers": null
@@ -1458,6 +1498,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "unit_price": 25,
         "total_price": 25,
         "price_includes_vat": true,
+        "commission": 2.32,
+        "commission_rate": 9.28,
         "island_vat_discount_applied": false,
         "serial_numbers": null
       }

--- a/source/localizable/smart_cart/webhook.html.md.erb
+++ b/source/localizable/smart_cart/webhook.html.md.erb
@@ -249,6 +249,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
     "store_pickup": false,
+    "commission": 4.05,
     "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
@@ -387,6 +388,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
     "store_pickup": false,
+    "commission": 5.32,
     "fbs_delivery_note": null
     "accept_options": {
       "number_of_parcels": [
@@ -517,6 +519,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
     "store_pickup": false,
+    "commission": 4.05,
     "fbs_delivery_note": null
   },
   "changes": {
@@ -597,6 +600,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
     "store_pickup": false,
+    "commission": 4.05,
     "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
@@ -737,6 +741,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
     "store_pickup": false,
+    "commission": 4.05,
     "fbs_delivery_note": null
     "pickup_window": { from: "2019-11-02T15:00:00+02:00", "to": "2019-11-02T16:00:00+02:00" },
     "number_of_parcels": 1,
@@ -838,6 +843,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
     "store_pickup": false,
+    "commission": 4.05,
     "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
@@ -990,6 +996,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
     "store_pickup": false,
+    "commission": 19.00,
     "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
@@ -1134,6 +1141,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
     "store_pickup": false,
+    "commission": 19.00,
     "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
@@ -1264,6 +1272,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
     "store_pickup": false,
+    "commission": 4.05,
     "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
@@ -1381,6 +1390,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
     "store_pickup": false,
+    "commission": 4.73,
     "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [
@@ -1511,6 +1521,7 @@ Would send a Webhook request payload just like if the order was cancelled by the
     "gift_wrap": false,
     "fulfilled_by_skroutz": false,
     "store_pickup": false,
+    "commission": 4.05
     "fbs_delivery_note": null,
     "accept_options": {
       "number_of_parcels": [

--- a/source/localizable/smart_cart/webhook.html.md.erb
+++ b/source/localizable/smart_cart/webhook.html.md.erb
@@ -227,7 +227,8 @@ Would send a Webhook request payload just like if the order was cancelled by the
         "island_vat_discount_applied": false,
         "ean": "1234567890123",
         "mpn": "JA-1059",
-        "serial_numbers": null
+        "serial_numbers": null,
+        "tags": ["plus_deal"]
       },
       {
         "id": "l39vKqxqh2",


### PR DESCRIPTION
We have updated the docs regarding:
1) commission + commission rate for line items (3e69cbc4badcf706c7188be9c8bc0a4a5d3b729b)
2) commission for suborder (2581976afd0ee0a5bcd4c5aa8019ec90a728d5cd)
3) mpn for products and variations (075ac77cf82e44c1956bd3eda7ec226a50656e37)
4) tags for line items, (1749b1d51b60a0c44cb53e41bdd4b80ba9f6a431)