### PR TITLE
Add `readjusted_vat` and `vat_ratio` attributes to order object

### DIFF
--- a/source/localizable/smart_cart/_order_object.html.md.erb
+++ b/source/localizable/smart_cart/_order_object.html.md.erb
@@ -156,6 +156,8 @@ Name                              | Type      | Description
 `line_items[_].return_reason` | String | User return reason (possible values: `faulty`, `wrong_product`, `withdrawal`, `wrong_size`)
 `line_items[_].serial_numbers` | String | Serial numbers for item, concatenated by ',', e.g. `SN12345,SN56789`
 `line_items[_].tags` | Array | A list of tags that characterize the line item (optional). Supported tags: `["plus_deal", "coupon_deal", "two_plus_deal", "price_optimizer", "cc_installments"]`
+`line_items[_].readjusted_vat` | Boolean | Whether the VAT has been readjusted for this line item (only applies to international orders)
+`line_items[_].vat_ratio` | Double | The VAT ratio for this line item
 
 #### Line item size
 


### PR DESCRIPTION
![Screenshot 2024-10-03 at 4 31 54 PM](https://github.com/user-attachments/assets/e8656589-7ecf-4a1f-8050-f2d90b7c9a15)
