### PR TITLE
Fix literal regex placeholder in footer copyright year

### DIFF
--- a/source/partials/_footer.erb
+++ b/source/partials/_footer.erb
@@ -3,7 +3,7 @@
     <div class="row">
 
       <div class="col-xs-12 col-sm-6 col-sm-push-6 text-right text-center-xs">
-        <span>&copy; 20[0-9]{2} <%= settings.full_company_name %></span>
+        <span>&copy; <%= Date.today.year %> <%= settings.full_company_name %></span>
         <span><%= t('footer.legal') %></span>
       </div>
 


### PR DESCRIPTION
## Summary

The footer copyright year was hardcoded as `20[0-9]{2}` — a regex-like placeholder that rendered literally in the DOM rather than evaluating to the current year.

## Change

Replace the placeholder in `source/partials/_footer.erb` with `<%= Date.today.year %>`, which Middleman evaluates at build time so each deploy bakes in the correct year.
