### PR TITLE
Include new "coupons" line item tag

### DIFF
--- a/source/localizable/smart_cart/_order_object.html.md.erb
+++ b/source/localizable/smart_cart/_order_object.html.md.erb
@@ -220,7 +220,7 @@ Value            | Description
 | `line_items[_].rejection_reason`            | String  | Rejection reason (possible values: `limited_stock`, `no_stock`, `discontinuation`, `wrong_price`, `content_mistake`)                                                                  |
 | `line_items[_].return_reason`               | String  | User return reason (possible values: `faulty`, `wrong_product`, `withdrawal`, `wrong_size`)                                                                                           |
 | `line_items[_].serial_numbers`              | String  | Serial numbers for item, concatenated by ',', e.g. `SN12345,SN56789`                                                                                                                  |
-| `line_items[_].tags`                        | Array   | A list of tags that characterize the line item (optional). Supported tags: `["plus_deal", "coupon_deal", "two_plus_deal", "price_optimizer", "cc_installments"]`                      |
+| `line_items[_].tags`                        | Array   | A list of tags that characterize the line item (optional). Supported tags: `["plus_deal", "coupon_deal", "two_plus_deal", "coupons", "price_optimizer", "cc_installments"]`                      |
 | `line_items[_].readjusted_vat`              | Boolean | Whether the VAT has been readjusted for this line item (only applies to international orders)                                                                                         |
 | `line_items[_].vat_ratio`                   | Double  | The VAT ratio for this line item                                                                                                                                                      |
 


### PR DESCRIPTION
The webhook for an order with a merchants coupon applied, will include the new "coupons" tag to the affected line items that had their price reduced due to absorbing the coupon price.